### PR TITLE
Feature: add support for random delay in running backups

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,9 @@ ENV NFS_TARGET=""
 ENV BACKUP_CRON="5 0 * * *"
 ENV RESTIC_INIT_ARGS=""
 
+# default to random delay 0-60 seconds for backups
+ENV RANDOM_DELAY="60"
+
 # Maintenance
 ENV RESTIC_MAINT_INTERVAL=7
 ENV RESTIC_MAINT_DAYS=30

--- a/backup.ps1
+++ b/backup.ps1
@@ -394,6 +394,9 @@ function Send-Healthcheck {
 }
 
 function Invoke-Main {
+    # random sleep delay
+    Start-RandomSleep
+
     # Start Backup Timer
     if ($UseHealthcheck) {
         Invoke-RestMethod "$hc_url/start" | Out-Null

--- a/config/config.ps1
+++ b/config/config.ps1
@@ -30,3 +30,9 @@ $CopyLocalRepo = $Env:COPY_LOCAL_REPO -eq "Y"
 # Paths to backup
 $BackupSources = @("/data")
 # $BackupSources["/data"] = @()
+
+function Start-RandomSleep {
+    $Delay = [int]$Env:RANDOM_DELAY ?? 0
+    $SleepDelay = Get-Random -Minimum 0 -Maximum $Delay
+    Start-Sleep -Seconds $SleepDelay
+}

--- a/run.ps1
+++ b/run.ps1
@@ -14,6 +14,7 @@ $remoteRepo = Join-Path $dir "/test/remoteRepo"
 
 $USE_HEALTHCHECK = $env:USE_HEALTHCHECK ?? "N"
 $HC_PING = $env:HC_PING ?? ""
+$RANDOM_DELAY = [int]$env:RANDOM_DELAY ?? 0  # dev env = no random sleep delays
 
 docker run --privileged --name backup-test `
     -h "restic-backup" `
@@ -23,6 +24,7 @@ docker run --privileged --name backup-test `
     -e "BACKUP_CRON=* * * * *" `
     -e "USE_HEALTHCHECK=$USE_HEALTHCHECK" `
     -e "HC_PING=$HC_PING" `
+    -e "RANDOM_DELAY=$RANDOM_DELAY"`
     -v "$($setA):/data" `
     -v "$($copy):/mnt/copy" `
     -v "$($remoteRepo):/mnt/restic" `


### PR DESCRIPTION
Use $Env:RANDOM_DELAY to configure a random delay for backups to avoid constantly causing traffic spikes at same time(s) of day